### PR TITLE
Add const iterator support and improve const correctness

### DIFF
--- a/Engine/Template/GameDefines.hpp
+++ b/Engine/Template/GameDefines.hpp
@@ -321,13 +321,13 @@ enum EClassCastFlag : uint32_t
 #pragma pack(push, 0x4)
 #endif
 
-template<typename TArray>
+template<typename TArrayType>
 class TIterator
 {
 public:
-	using ElementType = typename TArray::ElementType;
-	using ElementPointer = ElementType*;
-	using ElementReference = ElementType&;
+	using ElementType = typename std::remove_cv<TArrayType>::type::ElementType;
+	using ElementPointer = typename std::conditional<std::is_const<TArrayType>::value, const ElementType*, ElementType*>::type;
+	using ElementReference = typename std::conditional<std::is_const<TArrayType>::value, const ElementType&, ElementType&>::type;
 	using ElementConstReference = const ElementType&;
 
 private:
@@ -374,7 +374,17 @@ public:
 		return IteratorData;
 	}
 
+	ElementPointer operator->() const
+	{
+		return IteratorData;
+	}
+
 	ElementReference operator*()
+	{
+		return *IteratorData;
+	}
+
+	ElementReference operator*() const
 	{
 		return *IteratorData;
 	}
@@ -401,6 +411,7 @@ public:
 	using ElementConstPointer = const ElementType*;
 	using ElementConstReference = const ElementType&;
 	using Iterator = TIterator<TArray<ElementType>>;
+	using ConstIterator = TIterator<const TArray<InElementType>>;
 
 private:
 	ElementPointer ArrayData;
@@ -440,23 +451,37 @@ public:
 		return ArrayData[index];
 	}
 
+	ElementConstPointer data()
+	{
+		return ArrayData;
+	}
+
 	ElementConstPointer data() const
 	{
 		return ArrayData;
 	}
 
-	void push_back(ElementConstReference newElement)
+	void push_back(const ElementType& value)  // copy
 	{
 		if (ArrayCount >= ArrayMax)
 		{
 			ReAllocate(sizeof(ElementType) * (ArrayCount + 1));
 		}
 
-		new(&ArrayData[ArrayCount]) ElementType(newElement);
+		new(&ArrayData[ArrayCount]) ElementType(value);
 		ArrayCount++;
 	}
 
-	void push_back(ElementReference& newElement)
+	void push_back(ElementType&& value)  // move
+	{
+		if (ArrayCount >= ArrayMax)
+			ReAllocate(sizeof(ElementType) * (ArrayCount + 1));
+
+		new(&ArrayData[ArrayCount]) ElementType(std::move(value));
+		ArrayCount++;
+	}
+
+	void Add(ElementConstReference newElement)
 	{
 		if (ArrayCount >= ArrayMax)
 		{
@@ -511,9 +536,19 @@ public:
 		return Iterator(ArrayData);
 	}
 
+	ConstIterator begin() const
+	{
+		return ConstIterator(ArrayData);
+	}
+
 	Iterator end()
 	{
 		return Iterator(ArrayData + ArrayCount);
+	}
+
+	ConstIterator end() const
+	{
+		return ConstIterator(ArrayData + ArrayCount);
 	}
 
 private:


### PR DESCRIPTION
Adds ConstIterator support to TArray and simplifies push_back overloads for improved const correctness.

Changes:

    Added ConstIterator, begin() const, and end() const to TArray

    Added const overloads for operator* / operator-> in TIterator

    Removed redundant push_back(T&) overload - const T& already covers all valid use cases here, including rvalues and lvalues.

    Kept only push_back(const T&) and added push_back(T&&) for move support

Motivation:

    Enables iteration over const TArray

    Reduces overload duplication

    Preserves full compatibility with existing generated code